### PR TITLE
Fix incorrect DOIs in journals.json

### DIFF
--- a/data/journals.json
+++ b/data/journals.json
@@ -279,7 +279,7 @@
     "journal": "Genesis",
     "link": "http://view.ncbi.nlm.nih.gov/pubmed/26088819",
     "highImpact": false,
-    "doi": "10.1002/dvg.22842"
+    "doi": "10.1002/dvg.22867"
   },
   {
     "year": 2014,
@@ -288,7 +288,7 @@
     "journal": "Acta Crystallographica Section D",
     "link": "http://journals.iucr.org/d/issues/2014/01/00/lv5045/index.html",
     "highImpact": false,
-    "doi": "10.1107/S1399004713024838",
+    "doi": "10.1107/S139900471302364X",
     "notes": "Supplementary information and PreLysCar"
   },
   {
@@ -298,7 +298,7 @@
     "journal": "European Biophysics Journal",
     "link": "http://www.ncbi.nlm.nih.gov/pubmed/22484856",
     "highImpact": false,
-    "doi": "10.1007/s00249-012-0800-1"
+    "doi": "10.1007/s00249-012-0798-4"
   },
   {
     "year": 2012,
@@ -316,7 +316,7 @@
     "journal": "Biochimica et Biophysica Acta",
     "link": "http://www.ncbi.nlm.nih.gov/pubmed/22051023",
     "highImpact": false,
-    "doi": "10.1016/j.bbamem.2011.10.001"
+    "doi": "10.1016/j.bbamem.2011.09.026"
   },
   {
     "year": 2011,
@@ -335,7 +335,7 @@
     "journal": "IEEE Engineering in Medicine and Biology Society",
     "link": "http://www.ncbi.nlm.nih.gov/pubmed/19162917",
     "highImpact": false,
-    "doi": "10.1109/IEMBS.2008.4649344"
+    "doi": "10.1109/IEMBS.2008.4649414"
   },
   {
     "year": 2008,


### PR DESCRIPTION
This PR corrects 6 incorrect DOIs in the journals data that were pointing to wrong publications.

## Changes
Fixed DOIs for the following publications:
- **2015 Genesis** (`dictyBase 2015`): `10.1002/dvg.22842` → `10.1002/dvg.22867`
- **2014 Acta Cryst** (`Lysine Carboxylation`): `10.1107/S1399004713024838` → `10.1107/S139900471302364X`
- **2012 EBJ** (`Ionizable Side Chains`): `10.1007/s00249-012-0800-1` → `10.1007/s00249-012-0798-4`
- **2012 JMB** (`OmpF protein`): `10.1016/j.jmb.2012.01.041` → `10.1016/j.jmb.2012.02.043`
- **2011 BBA** (`Computational studies`): `10.1016/j.bbamem.2011.10.001` → `10.1016/j.bbamem.2011.09.026`
- **2008 IEEE** (`Detecting Remote Homologues`): `10.1109/IEMBS.2008.4649344` → `10.1109/IEMBS.2008.4649414`

All publication links were correct; only the DOI fields needed correction to match the actual articles.